### PR TITLE
Add fingerprint for OracleADF

### DIFF
--- a/plugins/oracleadf.rb
+++ b/plugins/oracleadf.rb
@@ -1,0 +1,17 @@
+Plugin.define do
+  name "OracleADF"
+  authors [
+    "Ostorlab",
+  ]
+  version "0.1"
+  description "Oracle ADF is an end-to-end Java EE framework that simplifies application development by providing out-of-the-box infrastructure services and a visual and declarative development experience."
+  website "https://www.oracle.com/database/technologies/developer-tools/adf/"
+
+  matches [
+    {
+      :search => "headers[X-ORACLE-DMS-ECID]",
+      :regexp => /.+/,
+      :name => "X-ORACLE-DMS-ECID Header Present"
+    },
+  ]
+end


### PR DESCRIPTION
This header `X-ORACLE-DMS-ECID` is commonly associated with Oracle Fusion Middleware products. That's why It was chosen since the vulnerability in hand is in the Oracle Application Development Framework (ADF), a product of Oracle Fusion Middleware (component: ADF Faces). 
![image](https://github.com/user-attachments/assets/e7771d3d-2195-4086-8a7b-efd85e1fff11)
