### PR TITLE
Add fingerprint for D-Link

### DIFF
--- a/plugins/dlink.rb
+++ b/plugins/dlink.rb
@@ -4,7 +4,7 @@ Plugin.define do
     "Ostorlab",
   ]
   version "0.1"
-  description "D-Link DIR-820L is a wireless router providing internet access and networking capabilities."
+  description "D-Link is a wireless router providing internet access and networking capabilities."
   website "http://www.dlink.com/"
 
   matches [

--- a/plugins/dlink.rb
+++ b/plugins/dlink.rb
@@ -1,0 +1,17 @@
+Plugin.define do
+  name "D-Link"
+  authors [
+    "Ostorlab",
+  ]
+  version "0.1"
+  description "D-Link DIR-820L is a wireless router providing internet access and networking capabilities."
+  website "http://www.dlink.com/"
+
+  matches [
+    {
+      :search => "body",
+      :regexp => /<a href="http:\/\/www.dlink.com\/us\/en\/support">/,
+      :name => "D-Link Support Link"
+    },
+  ]
+end


### PR DESCRIPTION
Add fingerprint for D-Link.

The choice of this indicator was based on an observation of the Firmware of a D-Link Router. 

![image](https://github.com/user-attachments/assets/3e5da859-ac54-4eea-93f0-1a1f0756a1ce)
