### PR TITLE
Add Fingerprint for Aruba Networks Access Points.

### DIFF
--- a/plugins/aruba_networks_ap.rb
+++ b/plugins/aruba_networks_ap.rb
@@ -1,0 +1,17 @@
+Plugin.define do
+  name "Aruba Networks Access Points"
+  authors [
+    "Ostorlab",
+  ]
+  version "0.1"
+  description "Aruba Networks Access Points provide secure Wi-Fi solutions for enterprises, and this fingerprint matches the login page for Aruba Access Points."
+  website "https://www.arubanetworks.com"
+
+  matches [
+    {
+      :search => "body",
+      :regexp => /<img id="aruba-logo" src="\/images\/aruba-hpe-logo.png" width="175" alt="Aruba Networks" title="Aruba Networks"/,
+      :name => "Aruba Networks Login Page Logo"
+    },
+  ]
+end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ebda0b71-9db6-4af7-8b0d-6d842e485c45)
