### PR TITLE
Add fingerprint for Cisco ASA

### DIFF
--- a/plugins/cisco_asa.rb
+++ b/plugins/cisco_asa.rb
@@ -1,0 +1,17 @@
+Plugin.define do
+  name "Cisco ASA"
+  authors [
+    "Ostorlab"
+  ]
+  version "0.1"
+  description "Cisco ASA Software delivers enterprise-class security capabilities for the ASA security family in a variety of form factors."
+  website "https://www.cisco.com/c/en/us/products/security/adaptive-security-appliance-asa-software/index.html"
+
+  matches [
+    {
+      :search => "body",
+      :regexp => /<img src="\/\+CSCOU\+\/csco_logo\.gif".*?SSL VPN Service/,
+      :name => "Cisco ASA SSL VPN page with logo and service name"
+    }
+  ]
+end


### PR DESCRIPTION
I couldn't properly test it on any target that uses Cisco ASA, because I kept getting this error. I guess we need to add support to unsafe legacy renegotiation, which is disabled by default in many modern SSL libraries.

![image](https://github.com/user-attachments/assets/c9f906f3-01be-4d1b-989b-6c0a87de98ef)
