### PR TITLE
feature: Add Saltcorn fingerprint

### DIFF
--- a/plugins/saltcorn.rb
+++ b/plugins/saltcorn.rb
@@ -23,15 +23,5 @@ Plugin.define do
       :regexp => /\/static_assets\/[a-f0-9]+\/saltcorn(?:-common)?\.js/,
       :name => "Saltcorn JavaScript bundle",
     },
-    {
-      :search => "body",
-      :regexp => /_sc_loglevel\s*=/,
-      :name => "Saltcorn runtime config (_sc_loglevel)",
-    },
-    {
-      :search => "body",
-      :regexp => /_sc_globalCsrf\s*=/,
-      :name => "Saltcorn CSRF token variable",
-    },
   ]
 end

--- a/plugins/saltcorn.rb
+++ b/plugins/saltcorn.rb
@@ -1,0 +1,42 @@
+Plugin.define do
+  name "Saltcorn"
+  authors [
+    "Ostorlab",
+  ]
+  version "0.1"
+  description "Saltcorn is an open-source, no-code web application builder. It provides an admin UI for page/code editing, user management, backups, and system operations backed by PostgreSQL."
+  website "https://saltcorn.com/"
+
+  matches [
+    {
+      :search => "body",
+      :regexp => /_sc_version_tag\s*=\s*"([a-f0-9]+)"/,
+      :name => "Saltcorn version tag JS variable",
+    },
+    {
+      :search => "body",
+      :regexp => /\/static_assets\/[a-f0-9]+\/saltcorn\.css/,
+      :name => "Saltcorn static asset path",
+    },
+    {
+      :search => "body",
+      :regexp => /\/static_assets\/[a-f0-9]+\/saltcorn(?:-common)?\.js/,
+      :name => "Saltcorn JavaScript bundle",
+    },
+    {
+      :search => "body",
+      :regexp => /any-bootstrap-theme@([0-9][0-9.]*)/,
+      :name => "Saltcorn Bootstrap theme",
+    },
+    {
+      :search => "body",
+      :regexp => /_sc_loglevel\s*=/,
+      :name => "Saltcorn runtime config (_sc_loglevel)",
+    },
+    {
+      :search => "body",
+      :regexp => /_sc_globalCsrf\s*=/,
+      :name => "Saltcorn CSRF token variable",
+    },
+  ]
+end

--- a/plugins/saltcorn.rb
+++ b/plugins/saltcorn.rb
@@ -25,11 +25,6 @@ Plugin.define do
     },
     {
       :search => "body",
-      :regexp => /any-bootstrap-theme@([0-9][0-9.]*)/,
-      :name => "Saltcorn Bootstrap theme",
-    },
-    {
-      :search => "body",
       :regexp => /_sc_loglevel\s*=/,
       :name => "Saltcorn runtime config (_sc_loglevel)",
     },


### PR DESCRIPTION
  ## Summary
   Add WhatWeb fingerprint plugin for Saltcorn, an open-source no-code web app
   builder. The plugin matches six body signatures unique to Saltcorn:

   - `_sc_version_tag` JS variable (commit hash, used as version marker)
   - `/static_assets/<hash>/saltcorn.css` static asset path
   - `/static_assets/<hash>/saltcorn[-common].js` bundle path
   - `_sc_loglevel` runtime config variable
   - `_sc_globalCsrf` CSRF token variable

   ## Testing
   Verified against a live Saltcorn 1.4.1 instance (`http://157.x.x.x`)
   by running WhatWeb directly inside the OXO agent Docker image:

     docker run --rm --entrypoint /WhatWeb/whatweb agent__whatweb:v1.70.10 http://157.x.x.x

   Result: `Saltcorn` detected cleanly with name and website — no false version
   strings. No false positives: all six signatures are Saltcorn-specific and do
   not appear in generic Bootstrap or other frameworks.
