### PR TITLE
fix: Get service name and hostnames as os env in mcp server process

### DIFF
--- a/agent/mcp_server/mcp_runner.py
+++ b/agent/mcp_server/mcp_runner.py
@@ -12,21 +12,11 @@ SERVER_PATH = "/app/agent/mcp_server/server.py"
 class MCPRunner:
     def __init__(
         self,
-        universe: str,
-        service_name: str,
         agent_key: str,
-        hostname: str,
-        host_hostname: str,
         agent_version: str = "",
-        logging_credentials: str = "",
     ) -> None:
-        self._universe: str = universe
-        self._service_name: str = service_name
         self._agent_key: str = agent_key
-        self._hostname: str = hostname
-        self._host_hostname: str = host_hostname
         self._agent_version: str = agent_version
-        self._logging_credentials: str = logging_credentials
 
     def run(self) -> None:
         """Start the MCP server process."""
@@ -34,19 +24,9 @@ class MCPRunner:
         command: list[str] = [
             "python3.14",
             SERVER_PATH,
-            "--universe",
-            self._universe,
-            "--service-name",
-            self._service_name,
             "--agent-key",
             self._agent_key,
-            "--hostname",
-            self._hostname,
-            "--host-hostname",
-            self._host_hostname,
             "--agent-version",
             self._agent_version,
-            "--logging-credentials",
-            self._logging_credentials,
         ]
         subprocess.Popen(command)

--- a/agent/mcp_server/server.py
+++ b/agent/mcp_server/server.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import os
 import time
 
 import click
@@ -35,22 +36,14 @@ MCP_SERVER_PORT = 50051
 
 def _configure_cloud_logging(
     logging_credential: str,
-    universe: str,
-    service_name: str,
     agent_key: str,
-    hostname: str,
-    host_hostname: str,
     version: str,
 ) -> None:
     """Set up the logging configuration.
 
     Args:
         logging_credential: Logging credential of gcp logging.
-        universe: scan universe id.
-        service_name: Docker service name of the agent.
         agent_key: Agent key.
-        hostname: Docker container hostname.
-        host_hostname: Scanner machine hostname.
         version: agent version.
 
     Returns:
@@ -67,10 +60,10 @@ def _configure_cloud_logging(
         labels={
             "agent_key": agent_key,
             "agent_version": version,
-            "universe": universe,
-            "service_name": service_name,
-            "hostname": hostname,
-            "host_hostname": host_hostname,
+            "universe": os.environ.get("UNIVERSE", "") or "",
+            "service_name": os.environ.get("SERVICE_NAME", "") or "",
+            "hostname": os.environ.get("HOSTNAME", "") or "",
+            "host_hostname": os.environ.get("HOST_HOSTNAME", "") or "",
         }
     )
     # GCO logging initialization is lazy, we need to log inorder trigger the init.
@@ -88,33 +81,21 @@ def _run() -> None:
 
 
 @click.command()
-@click.option("--universe", default="")
-@click.option("--service-name", default="")
 @click.option("--agent-key", default="")
-@click.option("--hostname", default="")
-@click.option("--host-hostname", default="")
 @click.option("--agent-version", default="")
-@click.option("--logging-credentials", default="")
 def main(
-    universe: str,
-    service_name: str,
     agent_key: str,
-    hostname: str,
-    host_hostname: str,
     agent_version: str,
-    logging_credentials: str,
 ) -> None:
     """Run the MCP server."""
 
-    _configure_cloud_logging(
-        logging_credential=logging_credentials,
-        universe=universe,
-        service_name=service_name,
-        agent_key=agent_key,
-        hostname=hostname,
-        host_hostname=host_hostname,
-        version=agent_version,
-    )
+    logging_credentials = os.environ.get("GCP_LOGGING_CREDENTIAL")
+    if logging_credentials is not None:
+        _configure_cloud_logging(
+            logging_credential=logging_credentials,
+            agent_key=agent_key,
+            version=agent_version,
+        )
     logger.info("Running mcp server..")
     _run()
 

--- a/agent/whatweb_agent.py
+++ b/agent/whatweb_agent.py
@@ -6,7 +6,6 @@ import io
 import ipaddress
 import json
 import logging
-import os
 import re
 import subprocess
 import tempfile
@@ -126,22 +125,12 @@ class AgentWhatWeb(
     def start(self) -> None:
         """Starts the agent and the MCP server if configured to do so."""
         if self._should_start_mcp_server is True:
-            universe: str = os.environ.get("UNIVERSE", "")
-            service_name: str = os.environ.get("SERVICE_NAME", "")
-            hostname: str = os.environ.get("HOSTNAME", "")
-            host_hostname: str = os.environ.get("HOST_HOSTNAME", "")
-            logging_credentials: str = os.environ.get("GCP_LOGGING_CREDENTIAL", "")
             version: str = self._agent_definition.version or ""
             agent_key: str = self.settings.key or ""
 
             runner = mcp_runner.MCPRunner(
-                universe=universe,
-                service_name=service_name,
                 agent_key=agent_key,
-                hostname=hostname,
-                host_hostname=host_hostname,
                 agent_version=version,
-                logging_credentials=logging_credentials,
             )
             logger.info("Starting MCP server..")
             runner.run()

--- a/tests/mcp_server/mcp_runner_test.py
+++ b/tests/mcp_server/mcp_runner_test.py
@@ -10,17 +10,10 @@ def testMCPRunner_whenRun_shouldCallPopenWithCorrectCommand(
 ) -> None:
     """Test MCPRunner run method."""
     popen_mock = mocker.patch("subprocess.Popen")
-    universe = "test_universe"
     agent_version = "1.0.0"
-    logging_credentials = "test_credentials"
     runner = mcp_runner.MCPRunner(
-        universe=universe,
-        service_name="whatweb",
         agent_key="agent/ostorlab/whatweb_agent",
-        hostname="7b3572cd4d39",
-        host_hostname="m5",
         agent_version=agent_version,
-        logging_credentials=logging_credentials,
     )
 
     runner.run()
@@ -28,20 +21,10 @@ def testMCPRunner_whenRun_shouldCallPopenWithCorrectCommand(
     expected_command = [
         "python3.14",
         mcp_runner.SERVER_PATH,
-        "--universe",
-        "test_universe",
-        "--service-name",
-        "whatweb",
         "--agent-key",
         "agent/ostorlab/whatweb_agent",
-        "--hostname",
-        "7b3572cd4d39",
-        "--host-hostname",
-        "m5",
         "--agent-version",
         "1.0.0",
-        "--logging-credentials",
-        "test_credentials",
     ]
 
     popen_mock.assert_called_once_with(


### PR DESCRIPTION
This PR gets the service name and hostname in the mcp server process instead of passing it as an argument to the subprocess.Popen().